### PR TITLE
added names to route navigations

### DIFF
--- a/lib/pages/class_home_page.dart
+++ b/lib/pages/class_home_page.dart
@@ -55,6 +55,8 @@ class ClassHomePage extends StatelessWidget {
                         Navigator.push(
                             context,
                             MaterialPageRoute(
+                              settings:
+                                  const RouteSettings(name: "add_student"),
                               builder: (pageContext) => AddStudentPage(
                                 callback: (student) {
                                   // on save button in AddStudentPage, add the student
@@ -71,6 +73,7 @@ class ClassHomePage extends StatelessWidget {
                         Navigator.push(
                             context,
                             MaterialPageRoute(
+                              settings: const RouteSettings(name: "add_group"),
                               builder: (pageContext) => AddGroupPage(
                                   students: state.students,
                                   callback: (group) {
@@ -105,6 +108,8 @@ class ClassHomePage extends StatelessWidget {
                         Navigator.push(
                           context,
                           MaterialPageRoute(
+                              settings:
+                                  const RouteSettings(name: "add_assessment"),
                               builder: (pageContext) => AddAssessmentPage(
                                     groups: state.groups,
                                     students: state.students,
@@ -148,6 +153,8 @@ class ClassHomePage extends StatelessWidget {
                           Navigator.push(
                             context,
                             MaterialPageRoute(
+                                settings:
+                                    const RouteSettings(name: "edit_student"),
                                 builder: (pageContext) => AddStudentPage(
                                       groups: state.groups,
                                       student: student,
@@ -164,6 +171,8 @@ class ClassHomePage extends StatelessWidget {
                           Navigator.push(
                             context,
                             MaterialPageRoute(
+                                settings:
+                                    const RouteSettings(name: "edit_group"),
                                 builder: (pageContext) => AddGroupPage(
                                       callback: (g) {
                                         // on save of group, edit the group
@@ -180,6 +189,8 @@ class ClassHomePage extends StatelessWidget {
                           Navigator.push(
                             context,
                             MaterialPageRoute(
+                                settings: const RouteSettings(
+                                    name: "edit_assessment"),
                                 builder: (pageContext) => AddAssessmentPage(
                                       groups: state.groups,
                                       students: state.students,

--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -69,6 +69,7 @@ class _LoginPageState extends State<LoginPage> {
             Navigator.pushReplacement(
                 context,
                 MaterialPageRoute(
+                  settings: const RouteSettings(name: "view_classes"),
                   builder: (context) => const ViewClassesPage(),
                 ));
           } else if (state is LoginPageError) {

--- a/lib/pages/view_classes_page.dart
+++ b/lib/pages/view_classes_page.dart
@@ -35,6 +35,7 @@ class ViewClassesPage extends StatelessWidget {
                         Navigator.push(
                             context,
                             MaterialPageRoute(
+                              settings: const RouteSettings(name: "add_class"),
                               builder: (context) => AddClassPage(
                                 callback: (theClass) {
                                   // on save button in AddStudentPage, add the student to the repo
@@ -119,6 +120,7 @@ class ViewClassesPage extends StatelessWidget {
                             Navigator.push(
                                 context,
                                 MaterialPageRoute(
+                                  settings: const RouteSettings(name: "home"),
                                   builder: (context) => ClassHomePage(
                                     theClass: state.classes[index],
                                   ),


### PR DESCRIPTION
Didn't replace all routes with named routes
Instead, just set the names at the time of pushing. Not sustainable, but also the only way I could find to get Firebase Analytics to record the screen name properly. Named routes did not have the same effect, but that could be because route settings were not passed through.

Closes #126 